### PR TITLE
Use normal session when app is in background

### DIFF
--- a/DownloadManager/Plugin.DownloadManager.Android/DownloadCompletedBroadcastReceiver.cs
+++ b/DownloadManager/Plugin.DownloadManager.Android/DownloadCompletedBroadcastReceiver.cs
@@ -1,8 +1,10 @@
 ﻿using System.Linq;
+using Android.App;
 using Android.Content;
 
 namespace Plugin.DownloadManager
 {
+    [BroadcastReceiver(Enabled = true, Exported = true), IntentFilter(new[] { Android.App.DownloadManager.ActionDownloadComplete })]
     public class DownloadCompletedBroadcastReceiver : BroadcastReceiver
     {
         public override void OnReceive (Context context, Intent intent)

--- a/DownloadManager/Plugin.DownloadManager.iOS/Plugin.DownloadManager.iOS.csproj
+++ b/DownloadManager/Plugin.DownloadManager.iOS/Plugin.DownloadManager.iOS.csproj
@@ -12,7 +12,7 @@
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AssemblyName>Plugin.DownloadManager</AssemblyName>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -25,7 +25,7 @@
     <CodesignKey>iPhone Developer</CodesignKey>
     <NoWarn>1591</NoWarn>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DebugType>none</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\iPhone\Release</OutputPath>

--- a/DownloadManager/Plugin.DownloadManager/CrossDownloadManager.cs
+++ b/DownloadManager/Plugin.DownloadManager/CrossDownloadManager.cs
@@ -22,6 +22,14 @@ namespace Plugin.DownloadManager
         /// @see https://developer.apple.com/library/ios/documentation/Foundation/Reference/NSURLSessionDownloadDelegate_protocol/#//apple_ref/occ/intfm/NSURLSessionDownloadDelegate/URLSession:downloadTask:didResumeAtOffset:expectedTotalBytes:
         /// </summary>
         public static UrlSessionDownloadDelegate UrlSessionDownloadDelegate;
+
+        /// <summary>
+        /// Wether you should use a normal download session configuration instead of as background download session configuration when the app is in the background to avoid the discretionary.
+        /// This makes the app download in the same process to be able to download immediately instead of waiting for the systems scheduling algorithm.
+        /// The download will however not continue if the app is suspended while downloading.
+        /// @see https://developer.apple.com/documentation/foundation/nsurlsessionconfiguration/1411552-discretionary?language=objc
+        /// </summary>
+        public static bool AvoidDiscretionaryDownloadInBackground;
 #endif
 
         /// <summary>
@@ -40,7 +48,7 @@ namespace Plugin.DownloadManager
         private static IDownloadManager CreateDownloadManager ()
         {
 #if __IOS__
-            return new DownloadManagerImplementation (UrlSessionDownloadDelegate ?? new UrlSessionDownloadDelegate());
+            return new DownloadManagerImplementation (UrlSessionDownloadDelegate ?? new UrlSessionDownloadDelegate(), AvoidDiscretionaryDownloadInBacgkround);
 #elif __ANDROID__ || __UNIFIED__ || WINDOWS_UWP
             return new DownloadManagerImplementation();
 #else


### PR DESCRIPTION
use the default session configuration when the app is in the background to avoid the discrtionary=true flag that apple automatically adds when you add a backgrounded download while the app is in background mode.