### PR TITLE
Set visibility for download notification on Android

### DIFF
--- a/DownloadManager/Plugin.DownloadManager.Android/DownloadFileImplementation.cs
+++ b/DownloadManager/Plugin.DownloadManager.Android/DownloadFileImplementation.cs
@@ -117,7 +117,7 @@ namespace Plugin.DownloadManager
         }
 
         public void StartDownload(Android.App.DownloadManager downloadManager, string destinationPathName,
-            bool allowedOverMetered)
+            bool allowedOverMetered, DownloadVisibility notificationVisibility)
         {
             using (var downloadUrl = Uri.Parse(Url))
             using (var request = new Android.App.DownloadManager.Request(downloadUrl))
@@ -136,6 +136,8 @@ namespace Plugin.DownloadManager
                 }
 
                 request.SetAllowedOverMetered(allowedOverMetered);
+
+                request.SetNotificationVisibility(notificationVisibility);
 
                 Id = downloadManager.Enqueue(request);
             }

--- a/DownloadManager/Plugin.DownloadManager.Android/DownloadManagerImplementation.cs
+++ b/DownloadManager/Plugin.DownloadManager.Android/DownloadManagerImplementation.cs
@@ -33,6 +33,8 @@ namespace Plugin.DownloadManager
 
         public Func<IDownloadFile, string> PathNameForDownloadedFile { get; set; }
 
+        public DownloadVisibility NotificationVisibility;
+
         public DownloadManagerImplementation ()
         {
             _queue = new List<IDownloadFile> ();
@@ -65,7 +67,7 @@ namespace Plugin.DownloadManager
                 destinationPathName = PathNameForDownloadedFile (file);
             }
 
-            file.StartDownload (_downloadManager, destinationPathName, mobileNetworkAllowed);
+            file.StartDownload (_downloadManager, destinationPathName, mobileNetworkAllowed, NotificationVisibility);
             AddFile (file);
         }
 

--- a/Sample/Droid/MainActivity.cs
+++ b/Sample/Droid/MainActivity.cs
@@ -21,6 +21,9 @@ namespace DownloadExample.Droid
             //    string fileName = Android.Net.Uri.Parse (file.Url).Path.Split ('/').Last ();
             //    return Path.Combine (ApplicationContext.GetExternalFilesDir (Android.OS.Environment.DirectoryDownloads).AbsolutePath, fileName);
             //});
+
+            // In case you want to create your own notification :)
+            //(CrossDownloadManager.Current as DownloadManagerImplementation).NotificationVisibility = DownloadVisibility.Hidden;
         }
 
         NotificationClickedBroadcastReceiver _receiverNotificationClicked;


### PR DESCRIPTION
Added a global way to set the visibility for download-notifications on Android. Feel free to leave any comments.

An idea would be to make it per file, but I don't know if that's needed. If you want, you can set it to a different value before starting a file ... which is quite clumsy, but will do the trick.