### PR TITLE
add possibility to prevent files from showing up in android download manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changes
 
+### 1.3.3
+
+  * Add possibility to prevent files from showing up in download manager
+
 ### 1.3.2
 
   * Fixed bug [#69](https://github.com/SimonSimCity/Xamarin-CrossDownloadManager/issues/69): Using PathNameForDownloadedFile: Android suffixes filename by '-1' if file already exists

--- a/DownloadManager/Plugin.DownloadManager.Android/DownloadFileImplementation.cs
+++ b/DownloadManager/Plugin.DownloadManager.Android/DownloadFileImplementation.cs
@@ -117,7 +117,7 @@ namespace Plugin.DownloadManager
         }
 
         public void StartDownload(Android.App.DownloadManager downloadManager, string destinationPathName,
-            bool allowedOverMetered, DownloadVisibility notificationVisibility)
+            bool allowedOverMetered, DownloadVisibility notificationVisibility, bool isVisibleInDownloadsUi)
         {
             using (var downloadUrl = Uri.Parse(Url))
             using (var request = new Android.App.DownloadManager.Request(downloadUrl))
@@ -141,6 +141,7 @@ namespace Plugin.DownloadManager
                     }
                 }
 
+                request.SetVisibleInDownloadsUi(isVisibleInDownloadsUi);
                 request.SetAllowedOverMetered(allowedOverMetered);
 
                 request.SetNotificationVisibility(notificationVisibility);

--- a/DownloadManager/Plugin.DownloadManager.Android/DownloadManagerImplementation.cs
+++ b/DownloadManager/Plugin.DownloadManager.Android/DownloadManagerImplementation.cs
@@ -35,6 +35,8 @@ namespace Plugin.DownloadManager
 
         public DownloadVisibility NotificationVisibility;
 
+        public bool IsVisibleInDownloadsUi { get; set; } = true; // true is the default behavior from Android DownloadManagerApi
+
         public DownloadManagerImplementation ()
         {
             _queue = new List<IDownloadFile> ();
@@ -67,7 +69,7 @@ namespace Plugin.DownloadManager
                 destinationPathName = PathNameForDownloadedFile (file);
             }
 
-            file.StartDownload (_downloadManager, destinationPathName, mobileNetworkAllowed, NotificationVisibility);
+            file.StartDownload (_downloadManager, destinationPathName, mobileNetworkAllowed, NotificationVisibility, IsVisibleInDownloadsUi);
             AddFile (file);
         }
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,14 @@ Just register the instance in `CrossDownloadManager.Current` in the library. Her
 
 I've created a quite basic implementation for UWP, iOS and Android which you can find [here](https://github.com/SimonSimCity/Xamarin-CrossDownloadManager/tree/develop/Sample). Feel free to fork this repository and play around with it. It's right within the `Sample` folder.
 
+### Why do the files show up in the native Android Download Manager?
+
+That is the default behavior when downloading files using the Android DownladManager API. If you don't want this to happen you can change the property IsVisibleInDownloadsUi of the DownloadManagerImplementation
+
+```
+	(CrossDownloadManager.Current as DownloadManagerImplementation).IsVisibleInDownloadsUi = true;
+```
+
 ### Contribute / Bugs / Features
 
 Everything you tell me is contributing to this project and helps me improving it. If you found a bug or want a feature, please file an issue to let me know. For bugs, please include as much information as you know. If you can, please fork this repository, reproduce the bug in the sample projects and include a link in the issue. For features, feel free to start developing them. I'm always willing to contribute, help and give advice.

--- a/Sample/Droid/MainActivity.cs
+++ b/Sample/Droid/MainActivity.cs
@@ -10,7 +10,7 @@ using System.IO;
 
 namespace DownloadExample.Droid
 {
-    [Activity (Label = "Download Example", MainLauncher = true, Icon = "@mipmap/icon")]
+    [Activity (Label = "Download Example", Name = "com.example.download_example.MainActivity", MainLauncher = true, Icon = "@mipmap/icon")]
     public class MainActivity : Activity
     {
         void InitDownloadManager ()
@@ -24,6 +24,9 @@ namespace DownloadExample.Droid
 
             // In case you want to create your own notification :)
             //(CrossDownloadManager.Current as DownloadManagerImplementation).NotificationVisibility = DownloadVisibility.Hidden;
+
+            // Prevents the file from appearing in the android download manager
+            (CrossDownloadManager.Current as DownloadManagerImplementation).IsVisibleInDownloadsUi = true;
         }
 
         NotificationClickedBroadcastReceiver _receiverNotificationClicked;
@@ -105,8 +108,6 @@ namespace DownloadExample.Droid
                             var nativeDownloadManager = (DownloadManager)ApplicationContext.GetSystemService (DownloadService);
                             System.Diagnostics.Debug.WriteLine (nativeDownloadManager.GetUriForDownloadedFile (((DownloadFileImplementation)sender).Id));
 
-                            // If you don't want your download to be listed in the native "Download" app after the download is finished
-                            //nativeDownloadManager.Remove(((DownloadFileImplementation)sender).Id);
                             break;
                         }
                     }


### PR DESCRIPTION
Right now the download files show up in the android download manager. This pull request adds configuration to prevent this.