### PR TITLE
Task.Resume() on resumed downloads and HttpMaximumConnectionsPerHost configuration

### DIFF
--- a/DownloadManager/Plugin.DownloadManager.iOS/DownloadManagerImplementation.cs
+++ b/DownloadManager/Plugin.DownloadManager.iOS/DownloadManagerImplementation.cs
@@ -55,7 +55,6 @@ namespace Plugin.DownloadManager
             _backgroundSession.GetTasks2((dataTasks, uploadTasks, downloadTasks) => {
                 foreach (var task in downloadTasks) {
                     AddFile(new DownloadFileImplementation(task));
-                    task.Resume();
                 }
             });
         }

--- a/DownloadManager/Plugin.DownloadManager.iOS/DownloadManagerImplementation.cs
+++ b/DownloadManager/Plugin.DownloadManager.iOS/DownloadManagerImplementation.cs
@@ -16,6 +16,8 @@ namespace Plugin.DownloadManager
         private string _identifier => NSBundle.MainBundle.BundleIdentifier + ".BackgroundTransferSession";
 
         private readonly bool _avoidDiscretionaryDownloadInBackground;
+        
+        private readonly int _httpMaximumConnectionsPerHost;
 
         private readonly NSUrlSession _backgroundSession;
         
@@ -36,9 +38,10 @@ namespace Plugin.DownloadManager
         public Func<IDownloadFile, string> PathNameForDownloadedFile { get; set; }
 
         public DownloadManagerImplementation (UrlSessionDownloadDelegate sessionDownloadDelegate,
-            bool avoidDiscretionaryDownloadInBackground)
+            bool avoidDiscretionaryDownloadInBackground, int httpMaximumConnectionsPerHost)
         {
             _avoidDiscretionaryDownloadInBackground = avoidDiscretionaryDownloadInBackground;
+            _httpMaximumConnectionsPerHost = httpMaximumConnectionsPerHost;
             _queue = new List<IDownloadFile> ();
 
             if (avoidDiscretionaryDownloadInBackground)
@@ -52,6 +55,7 @@ namespace Plugin.DownloadManager
             _backgroundSession.GetTasks2((dataTasks, uploadTasks, downloadTasks) => {
                 foreach (var task in downloadTasks) {
                     AddFile(new DownloadFileImplementation(task));
+                    task.Resume();
                 }
             });
         }
@@ -149,7 +153,7 @@ namespace Plugin.DownloadManager
         }
 
         private NSUrlSession createSession(NSUrlSessionConfiguration configuration, UrlSessionDownloadDelegate sessionDownloadDelegate) {
-            configuration.HttpMaximumConnectionsPerHost = 1;
+            configuration.HttpMaximumConnectionsPerHost = _httpMaximumConnectionsPerHost;
 
             return NSUrlSession.FromConfiguration(configuration, sessionDownloadDelegate, null);
         }

--- a/DownloadManager/Plugin.DownloadManager/CrossDownloadManager.cs
+++ b/DownloadManager/Plugin.DownloadManager/CrossDownloadManager.cs
@@ -30,6 +30,13 @@ namespace Plugin.DownloadManager
         /// @see https://developer.apple.com/documentation/foundation/nsurlsessionconfiguration/1411552-discretionary?language=objc
         /// </summary>
         public static bool AvoidDiscretionaryDownloadInBackground;
+        
+        /// <summary>
+        /// Set the HttpMaximumConnectionsPerHost for the NSUrlSessionConfiguration
+        /// It is recommended to leave this setting on it's default 1, as higher values might cause higher memory usage. However there are situations
+        /// where a higher value could make sense.
+        /// </summary>
+        public static int HttpMaximumConnectionsPerHost = 1;
 #endif
 
         /// <summary>
@@ -48,7 +55,7 @@ namespace Plugin.DownloadManager
         private static IDownloadManager CreateDownloadManager ()
         {
 #if __IOS__
-            return new DownloadManagerImplementation (UrlSessionDownloadDelegate ?? new UrlSessionDownloadDelegate(), AvoidDiscretionaryDownloadInBackground);
+            return new DownloadManagerImplementation (UrlSessionDownloadDelegate ?? new UrlSessionDownloadDelegate(), AvoidDiscretionaryDownloadInBackground, HttpMaximumConnectionsPerHost);
 #elif __ANDROID__ || __UNIFIED__ || WINDOWS_UWP
             return new DownloadManagerImplementation();
 #else


### PR DESCRIPTION
Patch1: Calling Task.Resume() in GetTasks2(...)

Patch2: Provide configuration option for HttpMaximumConnectionsPerHost